### PR TITLE
Get github key from cloud datastore instead of local file

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -20,3 +20,7 @@ __pycache__/
 
 sonarcloud/
 .eggs/
+.idea/
+adobeXDfiles/
+Psychiatric_Guide.egg-info/
+venv/

--- a/application/keys.py
+++ b/application/keys.py
@@ -1,1 +1,0 @@
-GITHUB_TOKEN = "Dummy Token"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django==2.1.7
 django-crispy-forms==1.7.2
 pymysql==0.9.3
 pygithub==1.43.5
+google-cloud-datastore==1.7.3


### PR DESCRIPTION
This will allow anyone to deploy to app engine without needing the github key for the bug report view. The program will now just grab the key from cloud datastore.